### PR TITLE
Feature/django1.8

### DIFF
--- a/bongo/settings/dev.py
+++ b/bongo/settings/dev.py
@@ -42,16 +42,9 @@ ALLOWED_HOSTS = [
 ]
 
 INSTALLED_APPS += (
-    'django_nose',
 )
 
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
-NOSE_ARGS = ['--with-fixture-bundling', '--nologcapture']
-
-NOSE_TESTMATCH = '(?:^|[b_./-])[Tt]ests'
-
-os.environ['REUSE_DB'] = '1'
+TEST_RUNNER = 'bongo.settings.tests.ReusableRunner'
 
 with open(os.path.normpath(os.path.join(SITE_ROOT, "ansible/env_vars/secure.yml")), "rb") as f:
     secrets = yaml.load(f)

--- a/bongo/settings/tests.py
+++ b/bongo/settings/tests.py
@@ -1,0 +1,10 @@
+from django.test.runner import DiscoverRunner
+
+class ReusableRunner(DiscoverRunner):
+    '''Custom test runner that reuses databases, if possible.'''
+
+    def __init__(self, **args):
+        super(ReusableRunner, self).__init__(
+            keepdb=True,
+            pattern="*_tests.py"
+        )

--- a/bongo/settings/travis.py
+++ b/bongo/settings/travis.py
@@ -16,11 +16,6 @@ DATABASES = {
 }
 
 INSTALLED_APPS += (
-    'django_nose',
 )
 
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
-NOSE_ARGS = ['--with-fixture-bundling', '--nologcapture', '--verbosity=2']
-
-NOSE_TESTMATCH = '(?:^|[b_./-])[Tt]ests'
+TEST_RUNNER = 'bongo.settings.tests.ReusableRunner'

--- a/reqs/common.txt
+++ b/reqs/common.txt
@@ -1,4 +1,4 @@
-django==1.7.5
+django==1.8.0
 djangorestframework==3.0.4
 django-cors-headers==0.12
 django-compressor==1.4

--- a/reqs/dev.txt
+++ b/reqs/dev.txt
@@ -2,4 +2,4 @@
 factory_boy==2.4.1
 fake-factory==0.4.2
 ipdb==0.8
-git+git://github.com/bjacobel/django-nose.git#egg=django-nose
+git+git://github.com/bjacobel/django-nose.git@0bc0f4ce777ad8379bee7092b7ef2cfb7b3a9e7d#egg=django-nose

--- a/reqs/dev.txt
+++ b/reqs/dev.txt
@@ -2,4 +2,3 @@
 factory_boy==2.4.1
 fake-factory==0.4.2
 ipdb==0.8
-git+git://github.com/bjacobel/django-nose.git@0bc0f4ce777ad8379bee7092b7ef2cfb7b3a9e7d#egg=django-nose

--- a/reqs/travis.txt
+++ b/reqs/travis.txt
@@ -2,5 +2,3 @@
 coveralls==0.4.1
 factory_boy==2.4.1
 fake-factory==0.4.2
-django-nose==1.3
-git+git://github.com/bjacobel/django-nose.git@0bc0f4ce777ad8379bee7092b7ef2cfb7b3a9e7d#egg=django-nose

--- a/reqs/travis.txt
+++ b/reqs/travis.txt
@@ -1,4 +1,4 @@
 -r prod.txt
-coveralls==0.4.1
+coveralls==1.0a2
 factory_boy==2.4.1
 fake-factory==0.4.2

--- a/reqs/travis.txt
+++ b/reqs/travis.txt
@@ -3,3 +3,4 @@ coveralls==0.4.1
 factory_boy==2.4.1
 fake-factory==0.4.2
 django-nose==1.3
+git+git://github.com/bjacobel/django-nose.git@0bc0f4ce777ad8379bee7092b7ef2cfb7b3a9e7d#egg=django-nose


### PR DESCRIPTION
Updates to Django 1.8.

Removes django-nose due to awful Django 1.8 compatibility issues.

Does not pass CI, reason being Celery. Wise architect that I am, I've already done the work of removing Celery in a different branch because it is shit and has all kinds of these compatibility issues. Will be merging that branch soon, CI will be back to green then.
