### PR TITLE
Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: false
 python:
   - "2.7"
-  - "3.4"
+  - "3.5"
 services:
   - postgresql
   - redis
@@ -14,7 +14,7 @@ cache:
   directories:
   - $HOME/.pip-cache/
   - /home/travis/virtualenv/python2.7.9
-  - /home/travis/virtualenv/python3.4.2
+  - /home/travis/virtualenv/python3.5.0
   - /home/travis/nltk_data
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 sudo: false
 python:
-  - "2.7"
-  - "3.5"
+  - 2.7
+  - 3.5.0
 services:
   - postgresql
   - redis

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -27,7 +27,7 @@
     - iftop
     - git
     - python-dev
-    - python3.4-dev
+    - python3.5-dev
     - python-pip
     - python3-pip
     - python-pycurl

--- a/readme.md
+++ b/readme.md
@@ -10,14 +10,14 @@ Bongo is using [waffle.io](http://waffle.io/BowdoinOrient/bongo) for project man
 ####Setup
 You'll need:
 
-- Python >=3.4
+- Python >=3.5
 - NodeJS >= 0.10
 - Postgres ([Postgres.app](http://postgresapp.com) is a good option if you're on OS X, `brew`'s postgres package always gives me issues).
 - Redis >= 2.8 (if you plan to contribute to scheduled task-related functionality)
 - Vagrant (if you plan to contribute to the project's Ansible playbook)
 - MySQL/MariaDB (if you plan to contribute changes to the project's adapter to the 2002-2015 database)
 
-Note that while all current development is being done with Python 3.4, the code base should support Python 2.7 if you are for some reason unable to upgrade.
+Note that while all current development is being done with Python 3.5, the code base should support Python 2.7 if you are for some reason unable to upgrade.
 
 1. Install [Homebrew](https://brew.sh).
 
@@ -56,7 +56,7 @@ Note that while all current development is being done with Python 3.4, the code 
 ####Tests
 You can run Bongo's test suite with `python manage.py test` (and should, often!). The current build status and test coverage stats are shown at the top of this readme. Pull requests should include tests to maintain or increase the current code coverage percentage.
 
-The test suite currently runs against both Python 2.7 and 3.4. so please ensure all pull requests are backwards-compatible (or forwards-, if developed with 2.7).
+The test suite currently runs against both Python 2.7 and 3.5, so please ensure all pull requests are backwards-compatible (or forwards-, if developed with 2.7).
 
 The test suite also runs a [PEP8](https://www.python.org/dev/peps/pep-0008/) linter (currently only in the CI environment, not in your dev env). Any PEP8 violations will cause the whole test suite to fail, so consider using a linter before you push to GitHub.
 
@@ -80,7 +80,6 @@ If you are contributing changes to the Ansible playbook, you may use the include
 and visit [http://bowdoinorient.local](http://bowdoinorient.local) in your browser if the deploy is successful.
 
 Bongo is currently deployed at [bowdoinorient.co](http://bowdoinorient.co).
-
 
 ####Using the API
 Bongo includes a JSON API acessible at [<base_url>/api/v1](https://bowdoinorient.bjacobel.com/api/v1). Its structure is fairly standard REST.

--- a/reqs/common.txt
+++ b/reqs/common.txt
@@ -3,7 +3,7 @@ djangorestframework==3.0.4
 django-cors-headers==0.12
 psycopg2==2.5.2
 mysqlclient==1.3.5
-NLTK==3.0.1
+NLTK==3.0.5
 Pillow==2.7.0
 pytz==2014.10
 requests==2.5.1


### PR DESCRIPTION
Upgrade python 3.4 to python 3.5.

Haven't tested the ansible `apt-get install python3.5-dev` line yet but I don't see a reason it shouldn't work on 14.04.

~~Merge conflicts?~~
